### PR TITLE
Allow multiple title popovers in a row

### DIFF
--- a/ng-joyride.js
+++ b/ng-joyride.js
@@ -164,8 +164,7 @@
             this.currentStep = currentStep;
             this.heading = config.heading;
             this.content = $sce.trustAsHtml(config.text);
-            this.titleMainDiv = '<div id="ng-joyride-title" class="ng-joyride-title"></div>';
-            this.titleTemplateIdSelector = '#ng-joyride-title';
+            this.titleMainDiv = '<div class="ng-joyride-title"></div>';
             this.loadTemplateFn = loadTemplateFn;
             this.titleTemplate = config.titleTemplate || defaultTitleTemplate;
             this.hasReachedEndFn = hasReachedEndFn;
@@ -183,8 +182,8 @@
             var $fkEl;
 
             function generateTitle() {
-                $('body').append(this.titleMainDiv);
-                $fkEl = $(this.titleTemplateIdSelector);
+                $fkEl = $(this.titleMainDiv);
+                $('body').append($fkEl);
                 this.addClassToCurtain(this.curtainClass);
                 var promise = this.loadTemplateFn(this.titleTemplate);
                 promise.then(angular.bind(this,_compilePopover));


### PR DESCRIPTION
Right now you can't have multiple title popovers in a row. The next title popover gets added before the previous one is removed due to the 100ms $fkEl.fadeOut function. Because $fkEl is set by searching the DOM for an ID, the two Title object interfer with one another. If you create the DOM element before adding it, you can avoid this problem.
