### PR TITLE
Change goToPrev to handle multiple function steps

### DIFF
--- a/ng-joyride.js
+++ b/ng-joyride.js
@@ -371,23 +371,30 @@
                 }
                 function goToPrev() {
                     steps[currentStepCount].cleanUp();
-                    var previousStep = steps[currentStepCount - 1];
-                    if (previousStep.type === "location_change") {
-                        scope.$evalAsync(function () {
-                            previousStep.rollback();
-                        });
-                        currentStepCount = currentStepCount - 2;
-                        $timeout(generateStep, 100);
+                    var requires_timeout = false;
+                    currentStepCount -= 1;
 
-                    } else if (previousStep.type === "function") {
-                        previousStep.rollback();
-                        currentStepCount = currentStepCount - 2;
-                        $timeout(generateStep, 100);
-                    } else {
-                        currentStepCount--;
-                        generateStep();
+                    // Rollback previous steps until we hit a title or element.
+                    while ((steps[currentStepCount].type === "location_change" || steps[currentStepCount].type === "function")
+                            && currentStepCount >= 1) {
+                        requires_timeout = true;
+                        if (steps[currentStepCount].type == "location_change") {
+                            scope.$evalAsync(function () {
+                                steps[currentStepCount].rollback();
+                            })
+                        }
+                        else {
+                            steps[currentStepCount].rollback();
+                        }
+                        currentStepCount -= 1;
                     }
 
+                    if (requires_timeout) {
+                        $timeout(generateStep, 100);
+                    }
+                    else {
+                        generateStep();
+                    }
                 }
 
                 function skipDemo() {


### PR DESCRIPTION
Current implementation steps back one step, rolls it back, then
continues at the step before that.

Problem arises when there are two or more function steps in a row. When
it tries to back up over them, it rolls back the highest index function,
sets current to the previous function, then continues on, executing the
two functions, then plunking you back in the title/element step you were
on.

This change iterates backwards and rolls back until we hit a
title/element to handle this sequence.