### PR TITLE
fix(style): ensure form highlighting

### DIFF
--- a/ng-joyride.css
+++ b/ng-joyride.css
@@ -33,13 +33,13 @@
 }
 
 .ng-joyride-element-non-static{
-    z-index: 9999;
+    z-index: 9999 !important;
     box-shadow:         0px 0px 28px 0px rgba(50, 50, 50, 0.75);
 }
 
 .ng-joyride-element-static{
     position: relative;
-    z-index: 9999;
+    z-index: 9999 !important;
     background: #F3F3F3;
     box-shadow:         0px 0px 28px 0px rgba(50, 50, 50, 0.75);
 }


### PR DESCRIPTION
Bootstrap sets the z-index of items with the class `.form-control` to 2, thereby preventing the highlighting of those elements. We can use the `!important` flag to prevent this.