### PR TITLE
Support the http return format on AngularJS v1.3.x

### DIFF
--- a/ng-joyride.js
+++ b/ng-joyride.js
@@ -153,10 +153,10 @@
 
             }
 
-            function _generatePopover(html) {
+            function _generatePopover(response) {
                 $fkEl.popover({
                     title: this.heading,
-                    template: html,
+                    template: response.data,
                     content: this.popoverTemplate,
                     html: true,
                     placement: this.placement,
@@ -250,11 +250,11 @@
 
             }
 
-            function _compilePopover(html) {
+            function _compilePopover(response) {
                 var self = this;
                 this.scope.heading = this.heading;
                 this.scope.content = this.content;
-                $fkEl.html($compile(html.data)(this.scope));
+                $fkEl.html($compile(response.data)(this.scope));
                 if (this.hasReachedEndFn()) {
                     $('.nextBtn').text("Finish");
                 } else {


### PR DESCRIPTION
Get html template from response.data rather than response in 

$http.get(template, { cache: $templateCache }).then(function (response) { "response.data" ........} )