### PR TITLE
fixed unbound function to prevent click function

### DIFF
--- a/ng-joyride.js
+++ b/ng-joyride.js
@@ -131,7 +131,11 @@
                     return $(step.advanceOn.element).bind(step.advanceOn.event, step.goToNextFn);
                 }
                 if($fkEl){
-                    return $fkEl.on("click", angular.bind(step,stopEvent));
+                	var stopEventFn = angular.bind(step,stopEvent); 
+                	if(!$fkEl.stopEventFn)
+                		$fkEl.stopEventFn = new Array();
+                	$fkEl.stopEventFn[step.currentStep] = stopEventFn;
+                    return $fkEl.on("click", stopEventFn);
                 }
 
             }
@@ -140,7 +144,7 @@
                     return $(step.advanceOn.element).unbind(step.advanceOn.event, step.goToNextFn);
                 }
                 if($fkEl){
-                    return $fkEl.off("click", angular.bind(step,stopEvent));
+                	return $fkEl.off("click", $fkEl.stopEventFn[step.currentStep]);
                 }
 
             }


### PR DESCRIPTION
The prevent-click function, bound by joyride, persists also after joyride closed. Inspecting $fkEl, I noticed that off function, called to remove stopEvent, doesn't effect because the function returned by angular.bind it's not the same. (Bug detected with angular 1.2.28 and jquery 2.1.1)